### PR TITLE
Alex/admin config securty

### DIFF
--- a/src/Utils/CreateConfigurations.ts
+++ b/src/Utils/CreateConfigurations.ts
@@ -63,7 +63,7 @@ export class CreateConfigurations {
     context: BaseComponentContext,
     formDigestValue: string,
     listTitle: string
-  ) {
+  ): Promise<void> {
     const groupId = await CreateConfigurations.getMembersGroupIdAsync(context);
 
     const targetRoleDefinitionId =
@@ -91,7 +91,7 @@ export class CreateConfigurations {
     );
   }
 
-  private static async getMembersGroupIdAsync(context: BaseComponentContext) {
+  private static async getMembersGroupIdAsync(context: BaseComponentContext): Promise<string> {
     const membersGroupName = `${context.pageContext.web.title} Members`;
 
     const res = await fetch(
@@ -133,7 +133,7 @@ export class CreateConfigurations {
     context: BaseComponentContext,
     formDigestValue: string,
     listTitle: string
-  ) {
+  ): Promise<void> {
     await fetch(
       context.pageContext.web.absoluteUrl +
         "/_api/web/lists/getbytitle('" +
@@ -154,7 +154,7 @@ export class CreateConfigurations {
     formDigestValue: string,
     groupId: string,
     listTitle: string
-  ) {
+  ): Promise<void> {
     await fetch(
       context.pageContext.web.absoluteUrl +
         "/_api/web/lists/getbytitle('" +
@@ -179,7 +179,7 @@ export class CreateConfigurations {
     groupId: string,
     targetRoleDefinitionId: string,
     listTitle: string
-  ) {
+  ): Promise<void> {
     await fetch(
       context.pageContext.web.absoluteUrl +
         "/_api/web/lists/getbytitle('" +

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -37,7 +37,7 @@ export default function LaserficheAdminConfiguration(
 
   const redirectPage = window.location.origin + window.location.pathname;
 
-  function isAdmin() {
+  function isAdmin(): boolean {
     const permission = new SPPermission(
       props.context.pageContext.web.permissions.value
     );

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -20,6 +20,8 @@ import { ProblemDetails } from '@laserfiche/lf-repository-api-client';
 import styles from './LaserficheAdminConfiguration.module.scss';
 import { SPPermission } from '@microsoft/sp-page-context';
 
+const YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN = 'You do not have the necessary rights to view or edit the Laserfiche SharePoint Integration configuration. Please contact your administrator for help.';
+
 export default function LaserficheAdminConfiguration(
   props: ILaserficheAdminConfigurationProps
 ): JSX.Element {
@@ -106,72 +108,77 @@ export default function LaserficheAdminConfiguration(
     <React.StrictMode>
       <HashRouter>
         <Stack>
-          <div className={styles.loginButton}>
-            <lf-login
-              redirect_uri={redirectPage}
-              authorize_url_host_name={region}
-              redirect_behavior='Replace'
-              client_id={clientId}
-              ref={loginComponent}
-            />
-          </div>
-          <AdminMainPage
-            context={props.context}
-            loggedIn={loggedIn}
-            repoClient={repoClient}
-          />
-          {isAdmin() && <span>Test hello</span>}
-          <StackItem>
-            <Switch>
-              <Route
-                exact={true}
-                component={() => <HomePage />}
-                path='/HomePage'
+          {isAdmin() && (
+            <>
+              <div className={styles.loginButton}>
+                <lf-login
+                  redirect_uri={redirectPage}
+                  authorize_url_host_name={region}
+                  redirect_behavior='Replace'
+                  client_id={clientId}
+                  ref={loginComponent}
+                />
+              </div>
+              <AdminMainPage
+                context={props.context}
+                loggedIn={loggedIn}
+                repoClient={repoClient}
               />
-              <Route exact={true} component={() => <HomePage />} path='/' />
-              <Route
-                exact={true}
-                component={() => (
-                  <ManageConfigurationsPage context={props.context} />
-                )}
-                path='/ManageConfigurationsPage'
-              />
-              <Route
-                exact={true}
-                component={() => (
-                  <ManageMappingsPage
-                    context={props.context}
-                    isLoggedIn={loggedIn}
-                    repoClient={repoClient}
+              <StackItem>
+                <Switch>
+                  <Route
+                    exact={true}
+                    component={() => <HomePage />}
+                    path='/HomePage'
                   />
-                )}
-                path='/ManageMappingsPage'
-              />
-              <Route
-                exact={true}
-                component={() => (
-                  <AddNewManageConfiguration
-                    context={props.context}
-                    loggedIn={loggedIn}
-                    repoClient={repoClient}
+                  <Route exact={true} component={() => <HomePage />} path='/' />
+                  <Route
+                    exact={true}
+                    component={() => (
+                      <ManageConfigurationsPage context={props.context} />
+                    )}
+                    path='/ManageConfigurationsPage'
                   />
-                )}
-                path='/AddNewManageConfiguration'
-              />
-              <Route
-                exact={true}
-                render={(properties) => (
-                  <EditManageConfiguration
-                    {...properties}
-                    context={props.context}
-                    loggedIn={loggedIn}
-                    repoClient={repoClient}
+                  <Route
+                    exact={true}
+                    component={() => (
+                      <ManageMappingsPage
+                        context={props.context}
+                        isLoggedIn={loggedIn}
+                        repoClient={repoClient}
+                      />
+                    )}
+                    path='/ManageMappingsPage'
                   />
-                )}
-                path='/EditManageConfiguration/:name'
-              />
-            </Switch>
-          </StackItem>
+                  <Route
+                    exact={true}
+                    component={() => (
+                      <AddNewManageConfiguration
+                        context={props.context}
+                        loggedIn={loggedIn}
+                        repoClient={repoClient}
+                      />
+                    )}
+                    path='/AddNewManageConfiguration'
+                  />
+                  <Route
+                    exact={true}
+                    render={(properties) => (
+                      <EditManageConfiguration
+                        {...properties}
+                        context={props.context}
+                        loggedIn={loggedIn}
+                        repoClient={repoClient}
+                      />
+                    )}
+                    path='/EditManageConfiguration/:name'
+                  />
+                </Switch>
+              </StackItem>
+            </>
+          )}
+          {!isAdmin() &&
+          <span><b>{YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN}</b></span>}
         </Stack>
       </HashRouter>
     </React.StrictMode>

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -18,6 +18,7 @@ import { SPComponentLoader } from '@microsoft/sp-loader';
 import { getRegion } from '../../../Utils/Funcs';
 import { ProblemDetails } from '@laserfiche/lf-repository-api-client';
 import styles from './LaserficheAdminConfiguration.module.scss';
+import { SPPermission } from '@microsoft/sp-page-context';
 
 export default function LaserficheAdminConfiguration(
   props: ILaserficheAdminConfigurationProps
@@ -33,6 +34,14 @@ export default function LaserficheAdminConfiguration(
   const region = getRegion();
 
   const redirectPage = window.location.origin + window.location.pathname;
+
+  function isAdmin() {
+    const permission = new SPPermission(
+      props.context.pageContext.web.permissions.value
+    );
+    const isFullControl = permission.hasPermission(SPPermission.manageWeb);
+    return isFullControl;
+  }
 
   async function getAndInitializeRepositoryClientAndServicesAsync(): Promise<void> {
     const accessToken =
@@ -111,6 +120,7 @@ export default function LaserficheAdminConfiguration(
             loggedIn={loggedIn}
             repoClient={repoClient}
           />
+          {isAdmin() && <span>Test hello</span>}
           <StackItem>
             <Switch>
               <Route


### PR DESCRIPTION
- add security on admin config page is user is not a site admin
- add security on admin list (that admin config page edits) so that users cannot manually update the list
    - from [SharePoint documentation](https://learn.microsoft.com/en-us/sharepoint/dev/sp-add-ins/set-custom-permissions-on-a-list-by-using-the-rest-interface)