### PR TITLE
moved copyright beneath jekyll metadata

### DIFF
--- a/jekyll_files/docs/admin-documentation/adding-app-organization.md
+++ b/jekyll_files/docs/admin-documentation/adding-app-organization.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
-
 ---
 layout: default
 title: Adding App to Organization
 nav_order: 1
 parent: Laserfiche SharePoint Online Integration Administration Guide
 ---
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 # Adding App to Organization
 

--- a/jekyll_files/docs/admin-documentation/adding-app-to-sp-site.md
+++ b/jekyll_files/docs/admin-documentation/adding-app-to-sp-site.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
 ---
 layout: default
 title: Adding App to SharePoint Site
 nav_order: 2
 parent: Laserfiche SharePoint Online Integration Administration Guide
 ---
-
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 # Adding App to SharePoint Site
 
 ## Adding app via SharePoint store

--- a/jekyll_files/docs/admin-documentation/configuring-metadata-mappings.md
+++ b/jekyll_files/docs/admin-documentation/configuring-metadata-mappings.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
-
 ---
 layout: default
 title: Configuring Metadata Mappings
 nav_order: 4
 parent: Laserfiche SharePoint Online Integration Administration Guide
 ---
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 # Configuring Metadata Mappings
 

--- a/jekyll_files/docs/admin-documentation/index.md
+++ b/jekyll_files/docs/admin-documentation/index.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
 ---
 layout: default
 title: Laserfiche SharePoint Online Integration Administration Guide
 nav_order: 2
 has_children: true
 ---
-
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 # Laserfiche SharePoint Online Integration Administration Guide
 
 The following guides detail how to add the Laserfiche SharePoint Online integration. By default, you must be a tenant administrator to install the integration. Installing the integration involves the following steps:

--- a/jekyll_files/docs/admin-documentation/register-app-in-laserfiche.md
+++ b/jekyll_files/docs/admin-documentation/register-app-in-laserfiche.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
 ---
 layout: default
 title: Registering App in Laserfiche
 nav_order: 3
 parent: Laserfiche SharePoint Online Integration Administration Guide
 ---
-
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 # Registering App in Laserfiche
 
 ### Prerequisites

--- a/jekyll_files/docs/user-documentation/index.md
+++ b/jekyll_files/docs/user-documentation/index.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
 ---
 layout: default
 title: Laserfiche SharePoint Online Integration User Guide
 nav_order: 3
 has_children: true
 ---
-
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 # Laserfiche SharePoint Online Integration User Guide
 
 ## Overview

--- a/jekyll_files/docs/user-documentation/repository-explorer-usage.md
+++ b/jekyll_files/docs/user-documentation/repository-explorer-usage.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
-
 ---
 layout: default
 title: View Laserfiche Repository from SharePoint
 nav_order: 2
 parent: Laserfiche SharePoint Online Integration User Guide
 ---
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 # View Laserfiche Repository from SharePoint
 

--- a/jekyll_files/docs/user-documentation/sign-in-usage.md
+++ b/jekyll_files/docs/user-documentation/sign-in-usage.md
@@ -1,12 +1,11 @@
-<!--Copyright (c) Laserfiche.
-Licensed under the MIT License. See LICENSE in the project root for license information.-->
-
 ---
 layout: default
 title: Save a Document to Laserfiche
 nav_order: 1
 parent: Laserfiche SharePoint Online Integration User Guide
 ---
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 # Save a Document to Laserfiche
 

--- a/jekyll_files/index.md
+++ b/jekyll_files/index.md
@@ -3,6 +3,8 @@ layout: home
 title: Overview
 nav_order: 1
 ---
+<!--Copyright (c) Laserfiche.
+Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 # Working with the Laserfiche SharePoint Online Integration
 


### PR DESCRIPTION
putting the copyright comment above the jekyll metadata breaks jekyll's ability to parse the metadata. All pages which had content above the metadata did not display after adding the copyright comment (see image). moving the comment down fixes this issue.
![image](https://github.com/Laserfiche/laserfiche-sharepoint-integration/assets/122411121/7fb271fc-eec7-42b7-b604-335017247aaf)
