### PR TITLE
SharePoint bug fixes for Q1 release

### DIFF
--- a/src/webparts/laserficheAdminConfiguration/components/AddNewManageConfiguration/AddNewManageConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/AddNewManageConfiguration/AddNewManageConfiguration.tsx
@@ -19,6 +19,8 @@ import {
 } from '../../../constants';
 import { getSPListURL } from '../../../../Utils/Funcs';
 import styles from './../LaserficheAdminConfiguration.module.scss';
+import { ProfileConfigContext } from '../LaserficheAdminConfiguration';
+import { PROFILE_NAME } from '../../../strings';
 require('../../../../Assets/CSS/bootstrap.min.css');
 require('./../../../../Assets/CSS/commonStyles.css');
 require('../../../../../node_modules/bootstrap/dist/js/bootstrap.min.js');
@@ -49,14 +51,21 @@ const initialConfig: ProfileConfiguration = {
 export default function AddNewManageConfiguration(
   props: IAddNewManageConfigurationProps
 ): JSX.Element {
+  const {setSaveDisabled} = React.useContext(ProfileConfigContext);
   const [profileConfig, setProfileConfig] = useState(initialConfig);
   const [validate, setValidate] = useState(false);
   const [configNameError, setConfigNameError] = useState(undefined);
+
   const handleProfileConfigUpdate: (
     profileConfig: ProfileConfiguration
   ) => void = (profileConfig: ProfileConfiguration) => {
     setValidate(false);
     setProfileConfig(profileConfig);
+    const validate = validateNewConfiguration(profileConfig);
+    if (!validate) {
+      setValidate(true);
+      setSaveDisabled(true);
+    }
   };
   function handleProfileConfigNameChange(e: React.ChangeEvent): void {
     const newName = (e.target as HTMLInputElement).value;
@@ -64,6 +73,14 @@ export default function AddNewManageConfiguration(
     profileConfiguration.ConfigurationName = newName;
     setValidate(false);
     setProfileConfig(profileConfiguration);
+    const validate = validateNewConfiguration(profileConfiguration);
+    if (!validate) {
+      setValidate(true);
+      setSaveDisabled(true);
+    }
+    else {
+      setSaveDisabled(false);
+    }
   }
 
   async function saveSPConfigurationsAsync(
@@ -98,12 +115,14 @@ export default function AddNewManageConfiguration(
     }
   }
 
-  async function saveNewManageConfigurationAsync(): Promise<void> {
+  async function saveNewManageConfigurationAsync(): Promise<boolean> {
     setValidate(true);
     setConfigNameError(undefined);
+    setSaveDisabled(false);
     const validate = validateNewConfiguration(profileConfig);
     if (validate) {
-      const manageConfigurationConfig: IListItem[] = await GetItemIdForManageConfigurations();
+      const manageConfigurationConfig: IListItem[] =
+        await GetItemIdForManageConfigurations();
       if (manageConfigurationConfig?.length > 0) {
         const configWithCurrentName = manageConfigurationConfig[0];
         const savedProfileConfigurations: ProfileConfiguration[] =
@@ -119,16 +138,20 @@ export default function AddNewManageConfiguration(
             configWithCurrentName.Id,
             allConfigurations
           );
+          return true;
         } else {
+          setSaveDisabled(true);
           setConfigNameError(
             <span>
               Profile with this name already exists, please provide different
               name
             </span>
           );
+          return false;
         }
       } else {
         await saveNewPageConfigurationAsync();
+        return true;
       }
     } else {
       throw Error('Invalid configuration. Please review any errors.');
@@ -186,16 +209,20 @@ export default function AddNewManageConfiguration(
   let configNameValidation: JSX.Element | undefined;
   if (validate) {
     if (configNameError) {
+      setSaveDisabled(true);
       configNameValidation = configNameError;
     } else if (
       !profileConfig.ConfigurationName ||
       profileConfig.ConfigurationName.length === 0
     ) {
+      setSaveDisabled(true);
       configNameValidation = (
         <span>Please specify a name for this configuration</span>
       );
     } else if (/[^ A-Za-z0-9]/.test(profileConfig.ConfigurationName)) {
       // TODO can we allow special characters
+
+      setSaveDisabled(true);
       configNameValidation = (
         <span>Invalid Name, only alphanumeric or space are allowed.</span>
       );
@@ -207,11 +234,12 @@ export default function AddNewManageConfiguration(
       <h6 className='mb-0'>Add New Profile</h6>
     </div>
   );
+
   const extraConfiguration = (
     <>
       <div className={`${styles.formGroupRow} form-group row`}>
         <label htmlFor='txt0' className='col-sm-3 col-form-label'>
-          Profile Name <span style={{ color: 'red' }}>*</span>
+          {PROFILE_NAME} <span style={{ color: 'red' }}>*</span>
         </label>
         <div className='col-sm-6'>
           <input
@@ -233,18 +261,19 @@ export default function AddNewManageConfiguration(
     </>
   );
   return (
-    <ManageConfiguration
-      header={header}
-      extraConfiguration={extraConfiguration}
-      repoClient={props.repoClient}
-      loggedIn={props.loggedIn}
-      profileConfig={profileConfig}
-      loadingContent={true}
-      createNew={true}
-      context={props.context}
-      handleProfileConfigUpdate={handleProfileConfigUpdate}
-      saveConfiguration={saveNewManageConfigurationAsync}
-      validate={validate}
-    />
+      <ManageConfiguration
+        header={header}
+        repoClient={props.repoClient}
+        loggedIn={props.loggedIn}
+        profileConfig={profileConfig}
+        loadingContent={true}
+        createNew={true}
+        context={props.context}
+        handleProfileConfigUpdate={handleProfileConfigUpdate}
+        saveConfiguration={saveNewManageConfigurationAsync}
+        validate={validate}
+      >
+        {extraConfiguration}
+      </ManageConfiguration>
   );
 }

--- a/src/webparts/laserficheAdminConfiguration/components/AdminMainPage/AdminMainPage.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/AdminMainPage/AdminMainPage.tsx
@@ -24,9 +24,7 @@ export default function AdminMainPage(props: IAdminPageProps): JSX.Element {
   useEffect(() => {
     CreateConfigurations.ensureAdminConfigListCreatedAsync(props.context).catch(
       (err: Error) => {
-        console.warn(
-          `Error: ${err.message}`
-        );
+        console.warn(`Error: ${err.message}`);
       }
     );
   }, []);

--- a/src/webparts/laserficheAdminConfiguration/components/EditManageConfiguration/EditManageConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/EditManageConfiguration/EditManageConfiguration.tsx
@@ -92,7 +92,7 @@ export default function EditManageConfiguration(
     void initializeComponentAsync();
   }, []);
 
-  async function saveEditExistingConfigurationAsync(): Promise<void> {
+  async function saveEditExistingConfigurationAsync(): Promise<boolean> {
     setValidate(true);
     const validate = validateNewConfiguration(profileConfig);
     if (validate) {
@@ -114,8 +114,11 @@ export default function EditManageConfiguration(
             configWithCurrentName.Id,
             configsToSave
           );
+          return true;
         } else {
-          // error this config should exist
+          throw Error(
+            'Invalid configuration. This configuration no longer exists'
+          );
         }
       }
     } else {

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.module.scss
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.module.scss
@@ -190,3 +190,14 @@ lf-repository-browser {
   display: flex;
   align-items: center;
 }
+
+.templateWarning {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+.templateWarningMessage {
+  padding-left: 10px;
+}

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -40,6 +40,13 @@ const YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN =
 
 const needLaserficheSignInPage = `Missing "${LASERFICHE_SIGNIN_PAGE_NAME}" SharePoint page. Please refer to the Adding App to SharePoint Site topic in the administration guide for configuration steps.`;
 
+const YOU_MUST_BE_CLOUD_USER_TO_USE_WEB_PART =
+  'You must be a currently licensed Laserfiche Cloud user and SharePoint site administrator in order to manage profile configurations and mappings.';
+
+const PLEASE_LOGIN_TO_LASERFICHE =
+  'Please login to Laserfiche in order to use this web part.';
+const FOR_MORE_INFO_VISIT = 'For more information visit';
+
 interface ProfileConfigContextProps {
   saveDisabled: boolean;
   setSaveDisabled: React.Dispatch<React.SetStateAction<boolean>>;
@@ -48,7 +55,9 @@ export const ProfileConfigContext = React.createContext<
   ProfileConfigContextProps | undefined
 >(undefined);
 
-const ProfileConfigStateProvider = (props: React.PropsWithChildren<{}>): JSX.Element => {
+const ProfileConfigStateProvider = (
+  props: React.PropsWithChildren<{}>
+): JSX.Element => {
   const [saveDisabled, setSaveDisabled] = useState<boolean>(false);
 
   const contextValue = {
@@ -245,7 +254,6 @@ export default function LaserficheAdminConfiguration(
                 loggedIn={loggedIn}
                 repoClient={repoClient}
               />
-              {!loggedIn && <div>{PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS}</div>}
               <StackItem>
                 <Switch>
                   <Route
@@ -254,14 +262,12 @@ export default function LaserficheAdminConfiguration(
                     path='/HomePage'
                   />
                   <Route exact={true} component={() => <HomePage />} path='/' />
-                  {
-                    loggedIn && <>
+                  {loggedIn && (
+                    <>
                       <Route
                         exact={true}
                         component={() => (
-                          <ManageConfigurationsPage
-                            context={props.context}
-                          />
+                          <ManageConfigurationsPage context={props.context} />
                         )}
                         path='/ManageConfigurationsPage'
                       />
@@ -304,7 +310,7 @@ export default function LaserficheAdminConfiguration(
                         path='/EditManageConfiguration/:name'
                       />
                     </>
-                  }
+                  )}
                 </Switch>
               </StackItem>
             </>
@@ -314,6 +320,16 @@ export default function LaserficheAdminConfiguration(
               <b>
                 {YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN}
               </b>
+            </span>
+          )}
+          {!loggedIn && (
+            <span>
+              {`${PLEASE_LOGIN_TO_LASERFICHE}`}
+              {` ${YOU_MUST_BE_CLOUD_USER_TO_USE_WEB_PART} ${FOR_MORE_INFO_VISIT} `}
+              <a href='https://www.laserfiche.com/products/pricing'>
+                laserfiche.com
+              </a>
+              .
             </span>
           )}
           {messageErrorModal !== undefined && (

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -33,7 +33,6 @@ import { getRegion, getSPListURL } from '../../../Utils/Funcs';
 import styles from './LaserficheAdminConfiguration.module.scss';
 import { SPPermission } from '@microsoft/sp-page-context';
 import { MessageDialog } from '../../../extensions/savetoLaserfiche/CommonDialogs';
-import { PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS } from '../../strings';
 
 const YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN =
   'You do not have the necessary rights to view or edit the Laserfiche SharePoint Integration configuration. Please contact your administrator for help.';

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -40,12 +40,12 @@ const YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN =
 
 const needLaserficheSignInPage = `Missing "${LASERFICHE_SIGNIN_PAGE_NAME}" SharePoint page. Please refer to the Adding App to SharePoint Site topic in the administration guide for configuration steps.`;
 
-interface PropfileConfigContextProps {
-  saveDisabled: any;
-  setSaveDisabled: any;
+interface ProfileConfigContextProps {
+  saveDisabled: boolean;
+  setSaveDisabled: React.Dispatch<React.SetStateAction<boolean>>;
 }
 export const ProfileConfigContext = React.createContext<
-  PropfileConfigContextProps | undefined
+  ProfileConfigContextProps | undefined
 >(undefined);
 
 const ProfileConfigStateProvider = (props: React.PropsWithChildren<{}>) => {

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -33,11 +33,36 @@ import { getRegion, getSPListURL } from '../../../Utils/Funcs';
 import styles from './LaserficheAdminConfiguration.module.scss';
 import { SPPermission } from '@microsoft/sp-page-context';
 import { MessageDialog } from '../../../extensions/savetoLaserfiche/CommonDialogs';
+import { PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS } from '../../strings';
 
 const YOU_DO_NOT_HAVE_RIGHTS_FOR_ADMIN_CONFIG_PLEASE_CONTACT_ADMIN =
   'You do not have the necessary rights to view or edit the Laserfiche SharePoint Integration configuration. Please contact your administrator for help.';
 
 const needLaserficheSignInPage = `Missing "${LASERFICHE_SIGNIN_PAGE_NAME}" SharePoint page. Please refer to the Adding App to SharePoint Site topic in the administration guide for configuration steps.`;
+
+interface PropfileConfigContextProps {
+  saveDisabled: any;
+  setSaveDisabled: any;
+}
+export const ProfileConfigContext = React.createContext<
+  PropfileConfigContextProps | undefined
+>(undefined);
+
+const ProfileConfigStateProvider = (props: React.PropsWithChildren<{}>) => {
+  const [saveDisabled, setSaveDisabled] = useState<boolean>(false);
+
+  const contextValue = {
+    saveDisabled,
+    setSaveDisabled,
+  };
+
+  return (
+    <ProfileConfigContext.Provider value={contextValue}>
+      {props.children}
+    </ProfileConfigContext.Provider>
+  );
+};
+
 export default function LaserficheAdminConfiguration(
   props: ILaserficheAdminConfigurationProps
 ): JSX.Element {
@@ -138,7 +163,10 @@ export default function LaserficheAdminConfiguration(
         }
       }
     } catch (error) {
-      console.warn(`Unable to determine if a SharePoint Page with name ${LASERFICHE_SIGNIN_PAGE_NAME} exists.`, error);
+      console.warn(
+        `Unable to determine if a SharePoint Page with name ${LASERFICHE_SIGNIN_PAGE_NAME} exists.`,
+        error
+      );
       return false;
     }
     return false;
@@ -217,6 +245,7 @@ export default function LaserficheAdminConfiguration(
                 loggedIn={loggedIn}
                 repoClient={repoClient}
               />
+              {!loggedIn && <div>{PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS}</div>}
               <StackItem>
                 <Switch>
                   <Route
@@ -225,47 +254,57 @@ export default function LaserficheAdminConfiguration(
                     path='/HomePage'
                   />
                   <Route exact={true} component={() => <HomePage />} path='/' />
-                  <Route
-                    exact={true}
-                    component={() => (
-                      <ManageConfigurationsPage context={props.context} />
-                    )}
-                    path='/ManageConfigurationsPage'
-                  />
-                  <Route
-                    exact={true}
-                    component={() => (
-                      <ManageMappingsPage
-                        context={props.context}
-                        isLoggedIn={loggedIn}
-                        repoClient={repoClient}
+                  {
+                    loggedIn && <>
+                      <Route
+                        exact={true}
+                        component={() => (
+                          <ManageConfigurationsPage
+                            context={props.context}
+                          />
+                        )}
+                        path='/ManageConfigurationsPage'
                       />
-                    )}
-                    path='/ManageMappingsPage'
-                  />
-                  <Route
-                    exact={true}
-                    component={() => (
-                      <AddNewManageConfiguration
-                        context={props.context}
-                        loggedIn={loggedIn}
-                        repoClient={repoClient}
+                      <Route
+                        exact={true}
+                        component={() => (
+                          <ManageMappingsPage
+                            context={props.context}
+                            isLoggedIn={loggedIn}
+                            repoClient={repoClient}
+                          />
+                        )}
+                        path='/ManageMappingsPage'
                       />
-                    )}
-                    path='/AddNewManageConfiguration'
-                  />
-                  <Route
-                    exact={true}
-                    render={(properties) => (
-                      <EditManageConfiguration
-                        {...properties}
-                        context={props.context}
-                        loggedIn={loggedIn}
-                        repoClient={repoClient}
+                      <Route
+                        exact={true}
+                        component={() => (
+                          <ProfileConfigStateProvider>
+                            <AddNewManageConfiguration
+                              context={props.context}
+                              loggedIn={loggedIn}
+                              repoClient={repoClient}
+                            />
+                          </ProfileConfigStateProvider>
+                        )}
+                        path='/AddNewManageConfiguration'
                       />
-                    )}
-                    path='/EditManageConfiguration/:name'
-                  />
+                      <Route
+                        exact={true}
+                        render={(properties) => (
+                          <ProfileConfigStateProvider>
+                            <EditManageConfiguration
+                              {...properties}
+                              context={props.context}
+                              loggedIn={loggedIn}
+                              repoClient={repoClient}
+                            />
+                          </ProfileConfigStateProvider>
+                        )}
+                        path='/EditManageConfiguration/:name'
+                      />
+                    </>
+                  }
                 </Switch>
               </StackItem>
             </>

--- a/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/LaserficheAdminConfiguration.tsx
@@ -48,7 +48,7 @@ export const ProfileConfigContext = React.createContext<
   ProfileConfigContextProps | undefined
 >(undefined);
 
-const ProfileConfigStateProvider = (props: React.PropsWithChildren<{}>) => {
+const ProfileConfigStateProvider = (props: React.PropsWithChildren<{}>): JSX.Element => {
   const [saveDisabled, setSaveDisabled] = useState<boolean>(false);
 
   const contextValue = {

--- a/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationComponent.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationComponent.tsx
@@ -18,9 +18,10 @@ import {
   SPProfileConfigurationData,
 } from './ProfileConfigurationComponents';
 import styles from './LaserficheAdminConfiguration.module.scss';
+import { ProfileConfigContext } from './LaserficheAdminConfiguration';
 
 export default function ManageConfiguration(
-  props: IManageConfigurationProps
+  props: React.PropsWithChildren<IManageConfigurationProps>
 ): JSX.Element {
   const [availableLfTemplates, setAvailableLfTemplates] = useState<
     WTemplateInfo[] | undefined
@@ -32,7 +33,7 @@ export default function ManageConfiguration(
   >(undefined);
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const [showErrorModal, setShowErrorModal] = useState<string | undefined>();
-  const [saveDisabled, setSaveDisabled] = useState<boolean>(false);
+  const [templateWarning, setTemplateWarning] = useState<boolean>(false);
 
   async function getAllAvailableTemplates(): Promise<WTemplateInfo[]> {
     const repoId = await props.repoClient.getCurrentRepoId();
@@ -74,20 +75,30 @@ export default function ManageConfiguration(
         templates.sort();
         setAvailableLfTemplates(templates);
         if (props.profileConfig.selectedTemplateName) {
-          const templateFields: TemplateFieldInfo[] =
-            await getLaserficheFieldsAsync(
-              props.profileConfig.selectedTemplateName
+          const selectedTemplateExists = templates.find(
+            (r) => r.name === props.profileConfig.selectedTemplateName
+          );
+          if (selectedTemplateExists) {
+            const templateFields: TemplateFieldInfo[] =
+              await getLaserficheFieldsAsync(
+                props.profileConfig.selectedTemplateName
+              );
+            setLfFieldsForSelectedTemplate(templateFields);
+          } else {
+            setTemplateWarning(true);
+            templates.push(
+              new WTemplateInfo({
+                displayName: props.profileConfig.selectedTemplateName,
+              })
             );
-          setLfFieldsForSelectedTemplate(templateFields);
+          }
         }
         const spColumns: SPProfileConfigurationData[] =
           await getAllSharePointSiteColumnsAsync();
         spColumns.sort((a, b) => (a.Title > b.Title ? 1 : -1));
         setAvailableSPFields(spColumns);
       } catch (err) {
-        console.error(
-          `Error initializing configuration component: ${err}`
-        );
+        console.error(`Error initializing configuration component: ${err}`);
       }
     };
     if (props.repoClient) {
@@ -118,6 +129,9 @@ export default function ManageConfiguration(
     templateName: string
   ) => {
     const templateFields = await getLaserficheFieldsAsync(templateName);
+    setTemplateWarning(false);
+    const validTemplates = availableLfTemplates.filter((r) => r.id);
+    setAvailableLfTemplates(validTemplates);
     if (templateFields) {
       const array = [];
       for (let index = 0; index < templateFields.length; index++) {
@@ -158,13 +172,17 @@ export default function ManageConfiguration(
 
   async function saveConfigurationAsync(): Promise<void> {
     try {
-      await props.saveConfiguration();
-      setShowConfirmModal(true);
+      const success = await props.saveConfiguration();
+      if (success) {
+        setShowConfirmModal(true);
+      }
     } catch (err) {
       setShowErrorModal(err.message);
     }
   }
 
+  const { setSaveDisabled, saveDisabled } =
+    React.useContext(ProfileConfigContext);
   function hasError(hasError: boolean): void {
     if (hasError) {
       setSaveDisabled(true);
@@ -189,8 +207,9 @@ export default function ManageConfiguration(
                 {props.header}
               </div>
               <div className='card-body'>
-                {props.extraConfiguration}
+                {props.children}
                 <ConfigurationBody
+                  templateWarning={templateWarning}
                   availableLfTemplates={availableLfTemplates}
                   repoClient={props.repoClient}
                   loggedIn={props.loggedIn}
@@ -236,61 +255,65 @@ export default function ManageConfiguration(
           </div>
         </main>
       </div>
-      {showConfirmModal && <div
-        className={styles.modal}
-        data-backdrop='static'
-        data-keyboard='false'
-        id='ConfirmModal'
-      >
-        <div className='modal-dialog modal-dialog-centered'>
-          <div
-            className={`modal-content ${styles.modalContent} ${styles.wrapper}`}
-          >
-            <div className='modal-body'>
-              {props.createNew ? 'Profile Added' : 'Profile Updated'}
-            </div>
-            <div className='modal-footer'>
-              <button
-                type='button'
-                className='lf-button primary-button'
-                data-dismiss='modal'
-                onClick={onClickConfirmButton}
-              >
-                OK
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>}
-      {showErrorModal && <div
-        className={styles.modal}
-        data-backdrop='static'
-        data-keyboard='false'
-        id='ErrorModal'
-      >
-        <div className='modal-dialog modal-dialog-centered'>
-          <div
-            className={`modal-content ${styles.modalContent} ${styles.wrapper}`}
-          >
-            <div className={`modal-header ${styles.header}`}>
-              Error {props.createNew ? 'Saving' : 'Updating'} Profile
-            </div>
-            <div className={`modal-body ${styles.contentBox}`}>
-              {showErrorModal}
-            </div>
-            <div className={`modal-footer ${styles.footer}`}>
-              <button
-                type='button'
-                className='lf-button primary-button'
-                data-dismiss='modal'
-                onClick={onClickErrorButton}
-              >
-                OK
-              </button>
+      {showConfirmModal && (
+        <div
+          className={styles.modal}
+          data-backdrop='static'
+          data-keyboard='false'
+          id='ConfirmModal'
+        >
+          <div className='modal-dialog modal-dialog-centered'>
+            <div
+              className={`modal-content ${styles.modalContent} ${styles.wrapper}`}
+            >
+              <div className='modal-body'>
+                {props.createNew ? 'Profile Added' : 'Profile Updated'}
+              </div>
+              <div className='modal-footer'>
+                <button
+                  type='button'
+                  className='lf-button primary-button'
+                  data-dismiss='modal'
+                  onClick={onClickConfirmButton}
+                >
+                  OK
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>}
+      )}
+      {showErrorModal && (
+        <div
+          className={styles.modal}
+          data-backdrop='static'
+          data-keyboard='false'
+          id='ErrorModal'
+        >
+          <div className='modal-dialog modal-dialog-centered'>
+            <div
+              className={`modal-content ${styles.modalContent} ${styles.wrapper}`}
+            >
+              <div className={`modal-header ${styles.header}`}>
+                Error {props.createNew ? 'Saving' : 'Updating'} Profile
+              </div>
+              <div className={`modal-body ${styles.contentBox}`}>
+                {showErrorModal}
+              </div>
+              <div className={`modal-footer ${styles.footer}`}>
+                <button
+                  type='button'
+                  className='lf-button primary-button'
+                  data-dismiss='modal'
+                  onClick={onClickErrorButton}
+                >
+                  OK
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationProps.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationProps.tsx
@@ -7,7 +7,6 @@ import { ProfileConfiguration } from "./ProfileConfigurationComponents";
 
 export interface IManageConfigurationProps {
   header?: JSX.Element;
-  extraConfiguration?: JSX.Element;
   repoClient: IRepositoryApiClientExInternal;
   loggedIn: boolean;
   profileConfig: ProfileConfiguration;
@@ -16,5 +15,5 @@ export interface IManageConfigurationProps {
   context: WebPartContext;
   validate: boolean;
   handleProfileConfigUpdate: (profileConfig: ProfileConfiguration) => void;
-  saveConfiguration: () => Promise<void>;
+  saveConfiguration: () => Promise<boolean>;
 }

--- a/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationsPage/ManageConfigurationsPage.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationsPage/ManageConfigurationsPage.tsx
@@ -17,6 +17,7 @@ import {
   ProfileConfiguration,
 } from '../ProfileConfigurationComponents';
 import styles from './../LaserficheAdminConfiguration.module.scss';
+import { PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS } from '../../../strings';
 require('../../../../Assets/CSS/bootstrap.min.css');
 require('../../../../../node_modules/bootstrap/dist/js/bootstrap.min.js');
 
@@ -183,19 +184,19 @@ export default function ManageConfigurationsPage(
         <main className='bg-white shadow-sm'>
           <div className='card rounded-0'>
             <div className='card-header d-flex justify-content-between pt-1 pb-1'>
-              <NavLink
-                to='/AddNewManageConfiguration'
-                style={{
-                  marginRight: '18px',
-                  fontWeight: '500',
-                  fontSize: '15px',
-                  color: '#0079d6',
-                }}
-              >
-                <button className='lf-button primary-button'>
-                  {ADD_PROFILE}
-                </button>
-              </NavLink>
+                <NavLink
+                  to='/AddNewManageConfiguration'
+                  style={{
+                    marginRight: '18px',
+                    fontWeight: '500',
+                    fontSize: '15px',
+                    color: '#0079d6',
+                  }}
+                >
+                  <button className='lf-button primary-button'>
+                    {ADD_PROFILE}
+                  </button>
+                </NavLink>
             </div>
             <div className='card-body'>
               <table className='table table-bordered table-striped table-hover'>
@@ -221,7 +222,7 @@ export default function ManageConfigurationsPage(
           {deleteModal}
         </div>
       )}
-      {(error!== undefined) && (
+      {error !== undefined && (
         <div
           className={styles.modal}
           id='errorModal'

--- a/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationsPage/ManageConfigurationsPage.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/ManageConfigurationsPage/ManageConfigurationsPage.tsx
@@ -17,7 +17,6 @@ import {
   ProfileConfiguration,
 } from '../ProfileConfigurationComponents';
 import styles from './../LaserficheAdminConfiguration.module.scss';
-import { PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS } from '../../../strings';
 require('../../../../Assets/CSS/bootstrap.min.css');
 require('../../../../../node_modules/bootstrap/dist/js/bootstrap.min.js');
 

--- a/src/webparts/laserficheAdminConfiguration/components/ProfileConfigurationComponents.tsx
+++ b/src/webparts/laserficheAdminConfiguration/components/ProfileConfigurationComponents.tsx
@@ -18,6 +18,7 @@ import { ChangeEvent, useState } from 'react';
 import { IRepositoryApiClientExInternal } from '../../../repository-client/repository-client-types';
 import { getCorrespondingTypeFieldName } from '../../../Utils/Funcs';
 import styles from './LaserficheAdminConfiguration.module.scss';
+import { TEMPLATE_NO_LONGER_VALID_METADATA_WILL_NOT_BE_SAVED } from '../../strings';
 
 export interface ProfileConfiguration {
   ConfigurationName: string;
@@ -69,6 +70,7 @@ export function ConfigurationBody(props: {
   repoClient: IRepositoryApiClientExInternal;
   loggedIn: boolean;
   profileConfig: ProfileConfiguration;
+  templateWarning: boolean;
   handleProfileConfigUpdate: (config: ProfileConfiguration) => void;
   handleTemplateChange: (templateName: string) => void;
 }): JSX.Element {
@@ -131,6 +133,7 @@ export function ConfigurationBody(props: {
           availableLfTemplates={props.availableLfTemplates}
           selectedTemplateName={props.profileConfig?.selectedTemplateName}
           repoClient={props.repoClient}
+          templateWarning={props.templateWarning}
           onChangeTemplate={handleTemplateChange}
         />
       </div>
@@ -233,7 +236,7 @@ export function RepositoryBrowserModal(props: {
       lfRepoTreeService.viewableEntryTypes = [
         EntryType.Folder,
         EntryType.Shortcut,
-        EntryType.RecordSeries
+        EntryType.RecordSeries,
       ];
       void initializeTreeAsync();
     }
@@ -245,8 +248,8 @@ export function RepositoryBrowserModal(props: {
     if (node?.entryType === EntryType.Folder) {
       return true;
     } else if (
-     (node?.entryType === EntryType.Shortcut &&
-      node?.targetType === EntryType.Folder)
+      node?.entryType === EntryType.Shortcut &&
+      node?.targetType === EntryType.Folder
     ) {
       return true;
     } else {
@@ -383,6 +386,7 @@ export function TemplateSelector(props: {
   availableLfTemplates: WTemplateInfo[];
   selectedTemplateName: string;
   repoClient: IRepositoryApiClientExInternal;
+  templateWarning: boolean;
   onChangeTemplate: (event: ChangeEvent<HTMLSelectElement>) => void;
 }): JSX.Element {
   const laserficheTemplateOptions = props.availableLfTemplates?.map((item) => (
@@ -406,6 +410,16 @@ export function TemplateSelector(props: {
           {laserficheTemplateOptions}
         </select>
       </div>
+      {props.templateWarning && <div className={styles.templateWarning}>
+          <span
+            className='material-icons-outlined'
+            style={{
+              color: '#c59803',
+            }}
+          >
+            warning
+          </span>
+          <span className={styles.templateWarningMessage}>{TEMPLATE_NO_LONGER_VALID_METADATA_WILL_NOT_BE_SAVED}</span></div>}
     </>
   );
 }
@@ -703,7 +717,9 @@ function getMappingErrorMessage(
 ): JSX.Element | undefined {
   if (mappedField.lfField && mappedField.spField) {
     const spFieldtype = mappedField.spField.TypeAsString;
-    const lfFieldTypeDisplayName = getCorrespondingTypeFieldName(mappedField.lfField.fieldType);
+    const lfFieldTypeDisplayName = getCorrespondingTypeFieldName(
+      mappedField.lfField.fieldType
+    );
     const hasMismatch = hasFieldTypeMismatch(mappedField);
 
     if (hasMismatch) {

--- a/src/webparts/strings.ts
+++ b/src/webparts/strings.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE.md in the project root for license information.
+
+export const PLEASE_SIGNIN_TO_MANAGE_CONFIGURATIONS = 'Please sign in to manage configurations';
+export const TEMPLATE_NO_LONGER_VALID_METADATA_WILL_NOT_BE_SAVED ='Template is no longer valid for the selected repository. Metadata will not be saved.';
+export const PROFILE_NAME = 'Profile Name';


### PR DESCRIPTION
- "Popup says profile added when duplicate name should prevent addition"
      - Fix:  
![image](https://github.com/user-attachments/assets/f5c3d211-4c7e-4c65-ad8d-ddbac26f11db)

- "If configured Laserfiche template is deleted, profile configuration page does not show a good error"
      - Fix: show warning when viewing configuration. 
![image](https://github.com/user-attachments/assets/6ee294c7-a336-41af-bde7-514c5a8f664d)

- "SharePoint: Admin Configuration page appears interactive when user is logged out"
      - Fix: If user is logged out, (i.e. as soon as they attempt to do something that uses Laserfiche and the access token is removed from local storage) all administrator pages will display a message to log in.
      - 
![image](https://github.com/user-attachments/assets/b6c349c9-ba15-4b43-beec-a417c18027f3)