### PR TITLE
get content type using API if it doesn't exist on document properties

### DIFF
--- a/src/extensions/savetoLaserfiche/CommonDialogs.tsx
+++ b/src/extensions/savetoLaserfiche/CommonDialogs.tsx
@@ -10,6 +10,7 @@ import {
   LF_MS_OFFICE_LITE_CSS_URL,
 } from '../../webparts/constants';
 import { ActionTypes } from '../../webparts/laserficheAdminConfiguration/components/ProfileConfigurationComponents';
+import { CONTINUE } from '../../webparts/strings';
 
 const SAVING_DOCUMENT_TO_LASERFICHE = 'Saving document to Laserfiche...';
 
@@ -178,7 +179,7 @@ const createPromise: () => Promise<boolean>[] = () => {
 
 export const useConfirm: () => [
   (text: string) => Promise<unknown>,
-  (props: { cancelButtonText: string }) => JSX.Element
+  (props: { cancelButtonText: string; headerText: string }) => JSX.Element
 ] = () => {
   const [open, setOpen] = React.useState(false);
   const [resolver, setResolver] = React.useState({ resolve: null });
@@ -203,7 +204,11 @@ export const useConfirm: () => [
 
   const Confirmation: (props: {
     cancelButtonText: string;
-  }) => JSX.Element = (props: { cancelButtonText: string }) => (
+    headerText: string;
+  }) => JSX.Element = (props: {
+    cancelButtonText: string;
+    headerText: string;
+  }) => (
     <>
       {open && (
         <>
@@ -215,9 +220,7 @@ export const useConfirm: () => [
                   width='30'
                   height='30'
                 />
-                <span className={styles.paddingLeft}>
-                  Document already exists
-                </span>
+                <span className={styles.paddingLeft}>{props.headerText}</span>
               </div>
             </div>
           </div>
@@ -229,7 +232,7 @@ export const useConfirm: () => [
               className={`lf-button primary-button ${styles.actionButton}`}
               onClick={() => onClick(true)}
             >
-              Continue
+              {CONTINUE}
             </button>
             <button
               className='lf-button sec-button'

--- a/src/extensions/savetoLaserfiche/GetDocumentDataDialogUI.tsx
+++ b/src/extensions/savetoLaserfiche/GetDocumentDataDialogUI.tsx
@@ -34,7 +34,8 @@ import {
 import { IListItem } from '../../webparts/laserficheAdminConfiguration/components/IListItem';
 import { getSPListURL } from '../../Utils/Funcs';
 import { BaseComponentContext } from '@microsoft/sp-component-base';
-import LoadingDialog from './CommonDialogs';
+import LoadingDialog, { useConfirm } from './CommonDialogs';
+import { COULD_NOT_DETERMINE_CONTENT_TYPE, THERE_WAS_AN_ISSUE_DETERMINING_CONTENT_TYPE_OF_ITEM_DEFAULT_MAPPING_WILL_BE_USED } from '../../webparts/strings';
 
 const CANCEL = 'Cancel';
 const NO_SP_CONTENT_TYPE_EXISTS_AND_NO_DEFAULT_MAPPING =
@@ -63,6 +64,9 @@ export function GetDocumentDialogData(props: {
   >(undefined);
 
   const [error, setError] = React.useState<JSX.Element | undefined>(undefined);
+  const [getConfirmation, Confirmation] = useConfirm();
+
+  const [showLoading, setShowLoading] = React.useState<boolean>(false);
 
   const listFields = (
     <ul>
@@ -82,6 +86,21 @@ export function GetDocumentDialogData(props: {
   async function saveDocumentToLaserficheAsync(): Promise<void> {
     try {
       const libraryUrl = props.context.pageContext.list.title;
+
+      if (!props.spFileInfo.spContentType) {
+        const warn = await getConfirmation(THERE_WAS_AN_ISSUE_DETERMINING_CONTENT_TYPE_OF_ITEM_DEFAULT_MAPPING_WILL_BE_USED);
+        if (!warn) {
+          console.warn('Content type could not be determined. User chose to cancel operation.');
+          await props.handleCancelDialog();
+          return;
+        } else {
+          setShowLoading(true);
+        }
+      }
+      else {
+        setShowLoading(true);
+      }
+
       const allSPFieldValues: { [key: string]: string } =
         await getAllFieldsValuesAsync(libraryUrl, props.spFileInfo.fileId);
       const allSPFieldProperties: SPProfileConfigurationData[] =
@@ -382,43 +401,48 @@ export function GetDocumentDialogData(props: {
   }
 
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.header}>
-        <div className={styles.logoHeader}>
-          <img
-            src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAUVBMVEXSXyj////HYzL/+/T/+Or/9d+yaUa9ZT2yaUj/9OG7Zj3SXybRYCj/+/b///3LYS/OYCvEZDS2aEL/89jAZTnMYS3/8dO7Zzusa02+ZTn/78wyF0DsAAABnUlEQVR4nO3ci26CMABGYQcoLRS5OTf2/g86R+KSLYUm2vxcPB8RTYzxkADRajkcAAAAAAAAAADYgbJcusCvqdtLnhfeJR/a96X7vOriarNJ/cUtHeiTnI7p26TsY+XRZ190sXSfVyA6X7rP6xZdzeweREeTGDt3IBIdTeCUR3Q0wQOxLNf3CWSr0ZvcPYiWIFqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVV4zeok/379m9BL2HO1Ckymlky0jRQc3Kqoou4f6YHzdaLX56PRzak757/JjfDS0dbOK6HM6Paf8P3st6lVE/9mAwPOpNcnqokOIJppoookmmmiiiSaaaKKJ3k30OfTFdU3RXZ+lT6qq6rbO+k4VXQ9fvT2OrH30Zo+3u/5rUI17NO3QmdPImIduxoyrUze0khEm5w6uqZNIRKNi91Hl5661dH+tdow6wts5J//BaJPRwH6IT1NxbDJ6vVc+nrXJaAAAAADALn0DBosqnCStFi4AAAAASUVORK5CYII='
-            width='30'
-            height='30'
-          />
-          <span className={styles.paddingLeft}>Laserfiche</span>
+    <>
+      {showLoading && (
+        <div className={styles.wrapper}>
+          <div className={styles.header}>
+            <div className={styles.logoHeader}>
+              <img
+                src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAUVBMVEXSXyj////HYzL/+/T/+Or/9d+yaUa9ZT2yaUj/9OG7Zj3SXybRYCj/+/b///3LYS/OYCvEZDS2aEL/89jAZTnMYS3/8dO7Zzusa02+ZTn/78wyF0DsAAABnUlEQVR4nO3ci26CMABGYQcoLRS5OTf2/g86R+KSLYUm2vxcPB8RTYzxkADRajkcAAAAAAAAAADYgbJcusCvqdtLnhfeJR/a96X7vOriarNJ/cUtHeiTnI7p26TsY+XRZ190sXSfVyA6X7rP6xZdzeweREeTGDt3IBIdTeCUR3Q0wQOxLNf3CWSr0ZvcPYiWIFqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVYhWIVqFaBWiVV4zeok/379m9BL2HO1Ckymlky0jRQc3Kqoou4f6YHzdaLX56PRzak757/JjfDS0dbOK6HM6Paf8P3st6lVE/9mAwPOpNcnqokOIJppoookmmmiiiSaaaKKJ3k30OfTFdU3RXZ+lT6qq6rbO+k4VXQ9fvT2OrH30Zo+3u/5rUI17NO3QmdPImIduxoyrUze0khEm5w6uqZNIRKNi91Hl5661dH+tdow6wts5J//BaJPRwH6IT1NxbDJ6vVc+nrXJaAAAAADALn0DBosqnCStFi4AAAAASUVORK5CYII='
+                width='30'
+                height='30'
+              />
+              <span className={styles.paddingLeft}>Laserfiche</span>
+            </div>
+
+            <button
+              className={styles.lfCloseButton}
+              title='close'
+              onClick={props.handleCancelDialog}
+            >
+              <span className='material-icons-outlined'> close </span>
+            </button>
+          </div>
+
+          <div className={styles.contentBox}>
+            {!(missingFields?.length > 0) && !error && <LoadingDialog />}
+            {missingFields?.length > 0 && (
+              <MissingFieldsDialog missingFields={listFields} />
+            )}
+            {error}
+          </div>
+
+          <div className={styles.footer}>
+            <button
+              onClick={props.handleCancelDialog}
+              className='lf-button sec-button'
+            >
+              {CANCEL}
+            </button>
+          </div>
         </div>
-
-        <button
-          className={styles.lfCloseButton}
-          title='close'
-          onClick={props.handleCancelDialog}
-        >
-          <span className='material-icons-outlined'> close </span>
-        </button>
-      </div>
-
-      <div className={styles.contentBox}>
-        {!(missingFields?.length > 0) && !error && <LoadingDialog />}
-        {missingFields?.length > 0 && (
-          <MissingFieldsDialog missingFields={listFields} />
-        )}
-        {error}
-      </div>
-
-      <div className={styles.footer}>
-        <button
-          onClick={props.handleCancelDialog}
-          className='lf-button sec-button'
-        >
-          {CANCEL}
-        </button>
-      </div>
-    </div>
+      )}
+      <Confirmation cancelButtonText={CANCEL} headerText={COULD_NOT_DETERMINE_CONTENT_TYPE}/>
+    </>
   );
 }
 

--- a/src/extensions/savetoLaserfiche/SaveToLaserficheDialog.tsx
+++ b/src/extensions/savetoLaserfiche/SaveToLaserficheDialog.tsx
@@ -29,6 +29,7 @@ import { Entry } from '@laserfiche/lf-repository-api-client';
 import { RepositoryClientExInternal } from '../../repository-client/repository-client';
 import { IRepositoryApiClientExInternal } from '../../repository-client/repository-client-types';
 import { PathUtils } from '@laserfiche/lf-js-utils';
+import { CANCEL, DOCUMENT_ALREADY_EXISTS } from '../../webparts/strings';
 
 export default class SaveToLaserficheCustomDialog extends BaseDialog {
   successful = false;
@@ -253,7 +254,10 @@ function SaveToLaserficheDialog(props: {
           closeClick={saveToDialogCloseClick}
         />
       </div>
-      <Confirmation cancelButtonText='Cancel' />
+      <Confirmation
+        cancelButtonText={CANCEL}
+        headerText={DOCUMENT_ALREADY_EXISTS}
+      />
     </div>
   );
 

--- a/src/extensions/savetoLaserfiche/SavetoLaserficheCommandSet.tsx
+++ b/src/extensions/savetoLaserfiche/SavetoLaserficheCommandSet.tsx
@@ -105,22 +105,26 @@ export default class SendToLfCommandSet extends BaseListViewCommandSet<ISendToLf
   }
 
   private async getContentTypeAsync(itemId: string): Promise<string> {
-    const contentTypeUrl = `${getSPListURL(
-      this.context,
-      this.context.pageContext.list.title
-    )}/items(${itemId})/ContentType`;
-    const resp = await this.context.httpClient.get(
-      contentTypeUrl,
-      SPHttpClient.configurations.v1,
-      {
-        headers: {
-          Accept: 'application/json;',
-          'Content-Type': 'application/json;',
-        },
-      }
-    );
-    const val = await resp.json();
-    return val.d.Name;
+    try {
+      const contentTypeUrl = `${getSPListURL(
+        this.context,
+        this.context.pageContext.list.title
+      )}/items(${itemId})/ContentType`;
+      const resp = await this.context.httpClient.get(
+        contentTypeUrl,
+        SPHttpClient.configurations.v1,
+        {
+          headers: {
+            Accept: 'application/json;',
+            'Content-Type': 'application/json;',
+          },
+        }
+      );
+      const val = await resp.json();
+      return val.Name;
+    } catch {
+      return undefined;
+    }
   }
 
   public async pageConfigurationCheck(): Promise<void> {

--- a/src/extensions/savetoLaserfiche/SavetoLaserficheCommandSet.tsx
+++ b/src/extensions/savetoLaserfiche/SavetoLaserficheCommandSet.tsx
@@ -11,9 +11,13 @@ import {
   RowAccessor,
 } from '@microsoft/sp-listview-extensibility';
 import { PathUtils } from '@laserfiche/lf-js-utils';
+import { SPHttpClient } from '@microsoft/sp-http';
 import { CreateConfigurations } from '../../Utils/CreateConfigurations';
 import { getSPListURL } from '../../Utils/Funcs';
-import { LASERFICHE_SIGNIN_PAGE_NAME, SP_LOCAL_STORAGE_KEY } from '../../webparts/constants';
+import {
+  LASERFICHE_SIGNIN_PAGE_NAME,
+  SP_LOCAL_STORAGE_KEY,
+} from '../../webparts/constants';
 
 /**
  * If your command set uses the ClientSideComponentProperties JSON input,
@@ -59,9 +63,13 @@ export default class SendToLfCommandSet extends BaseListViewCommandSet<ISendToLf
     const fileSize = spDocumentProperties.getValueByName('File_x0020_Size');
     const fileUrl = spDocumentProperties.getValueByName('FileRef');
     const fileName = spDocumentProperties.getValueByName('FileLeafRef');
-    const spContentType = spDocumentProperties.getValueByName('ContentType');
     const isCheckedOut =
       spDocumentProperties.getValueByName('CheckoutUser')?.length > 0;
+
+    let spContentType = spDocumentProperties.getValueByName('ContentType');
+    if (!spContentType) {
+      spContentType = await this.getContentTypeAsync(fileId);
+    }
 
     await this.pageConfigurationCheck();
 
@@ -94,6 +102,25 @@ export default class SendToLfCommandSet extends BaseListViewCommandSet<ISendToLf
         fileId,
       });
     }
+  }
+
+  private async getContentTypeAsync(itemId: string): Promise<string> {
+    const contentTypeUrl = `${getSPListURL(
+      this.context,
+      this.context.pageContext.list.title
+    )}/items(${itemId})/ContentType`;
+    const resp = await this.context.httpClient.get(
+      contentTypeUrl,
+      SPHttpClient.configurations.v1,
+      {
+        headers: {
+          Accept: 'application/json;',
+          'Content-Type': 'application/json;',
+        },
+      }
+    );
+    const val = await resp.json();
+    return val.d.Name;
   }
 
   public async pageConfigurationCheck(): Promise<void> {

--- a/src/webparts/LaserficheRepositoryAccessWebPart/components/RepositoryViewWebPart.tsx
+++ b/src/webparts/LaserficheRepositoryAccessWebPart/components/RepositoryViewWebPart.tsx
@@ -35,8 +35,10 @@ import {
   CANNOT_IMPORT_INTO_RECORD_SERIES,
   CLOSE,
   CREATE_FOLDER,
+  DOCUMENT_ALREADY_EXISTS,
   ENTRY_WITH_SAME_NAME_EXISTS_IN_FOLDER_IF_CONTINUE_LF_WILL_RENAME,
   FOLDER_NAME,
+  GO_BACK,
   LASERFICHE_REPOSITORY_EXPLORER,
   NAME,
   OK,
@@ -737,7 +739,10 @@ function ImportFileModal(props: {
             {CANCEL}
           </button>
         </div>
-        <Confirmation cancelButtonText='Go back' />
+        <Confirmation
+          cancelButtonText={GO_BACK}
+          headerText={DOCUMENT_ALREADY_EXISTS}
+        />
       </div>
     </div>
   );

--- a/src/webparts/strings.ts
+++ b/src/webparts/strings.ts
@@ -59,7 +59,8 @@ export const CANNOT_IMPORT_INTO_RECORD_SERIES =
 export const UPLOAD_FILE_TO_LASERFICHE = 'Upload file to Laserfiche';
 export const UPLOAD_FILE_TO_LASERFICHE_TITLE = 'Upload File to Laserfiche';
 
-export const PLEASE_SELECT_FILE_FOLDER_TO_OPEN = 'Please select file/folder to open';
+export const PLEASE_SELECT_FILE_FOLDER_TO_OPEN =
+  'Please select file/folder to open';
 
 export const ENTRY_WITH_SAME_NAME_EXISTS_IN_FOLDER_IF_CONTINUE_LF_WILL_RENAME =
   'An entry with the same name already exists in the specified folder. If you continue, Laserfiche will automatically rename the new document.';
@@ -74,4 +75,14 @@ export const FOLDER_NAME = 'Folder Name';
 
 export const SUBMIT = 'Submit';
 export const CLOSE = 'Close';
-export const PROFILE_WITH_NAME_ALREADY_EXISTS_PROVIDE_DIFFERENT_NAME = 'Profile with this name already exists, please provide different name';
+export const PROFILE_WITH_NAME_ALREADY_EXISTS_PROVIDE_DIFFERENT_NAME =
+  'Profile with this name already exists, please provide different name';
+export const THERE_WAS_AN_ISSUE_DETERMINING_CONTENT_TYPE_OF_ITEM_DEFAULT_MAPPING_WILL_BE_USED =
+  'There was an issue determining the content type of the selected item. The default mapping will be used if it exists.';
+export const COULD_NOT_DETERMINE_CONTENT_TYPE =
+  'Could not determine content type';
+
+export const DOCUMENT_ALREADY_EXISTS = 'Document already exists';
+export const GO_BACK = 'Go back';
+
+export const CONTINUE = 'Continue';


### PR DESCRIPTION
- If content type is not on initial document properties, make an API call to retrieve content type
    - Actual change: [SaveToLaserficheCommandSet 107-128](https://github.com/Laserfiche/laserfiche-sharepoint-integration/pull/90/files#diff-3ea0c30f9bdc070a5092479c92e9f71e0fb304f1e4aa713253f176dc8b54b593:~:text=%7D-,private%20async%20getContentTypeAsync(itemId%3A%20string)%3A%20Promise%3C,%7D,-public%20async%20pageConfigurationCheck)
- Add dialog to warn user if content type cannot be determined. After this bug, this would be "unexpected" but at least in this case, it's won't default silently
     - [GetDocumentDialogUI 90-102](https://github.com/Laserfiche/laserfiche-sharepoint-integration/pull/90/files#:~:text=.title%3B-,if%20(!props.spFileInfo.spContentType)%20%7B,%7D,-const%20allSPFieldValues%3A)
     - 
![image](https://github.com/user-attachments/assets/334eaf1c-5c40-44d3-b9c9-cf4e7ebdf438)


- All other changes are formatting, will get strings reviewed
     